### PR TITLE
feat(cpu): cpu temperature component to cputemp

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -49,7 +49,7 @@ network:
   order: 0
   device: "enp6s0"
 
-cpu:
+cputemp:
   # interval: "500ms" # equivalent to 0.5 seconds
   order: 1
   sensor: "temp1_input"

--- a/pkg/cpu/temp/temp.go
+++ b/pkg/cpu/temp/temp.go
@@ -1,4 +1,4 @@
-package cpu
+package cputemp
 
 import (
 	"fmt"
@@ -11,14 +11,14 @@ import (
 	"github.com/freddiehaddad/swaybar/pkg/utils"
 )
 
-type CPU struct {
+type CPUTemp struct {
 	Sensor   string
 	Interval time.Duration
 	Enabled  atomic.Bool
 }
 
-func New(sensor string, interval time.Duration) (*CPU, error) {
-	cpu := &CPU{
+func New(sensor string, interval time.Duration) (*CPUTemp, error) {
+	cpu := &CPUTemp{
 		Sensor:   sensor,
 		Interval: interval,
 	}
@@ -27,10 +27,10 @@ func New(sensor string, interval time.Duration) (*CPU, error) {
 	return cpu, nil
 }
 
-func (c *CPU) Update() (descriptor.Descriptor, error) {
+func (c *CPUTemp) Update() (descriptor.Descriptor, error) {
 	log.Println("Updating CPU temperature sensor", c.Sensor)
 	descriptor := descriptor.Descriptor{
-		Component: "cpu",
+		Component: "cputemp",
 		Value:     "",
 	}
 	var sb strings.Builder
@@ -48,7 +48,7 @@ func (c *CPU) Update() (descriptor.Descriptor, error) {
 	return descriptor, nil
 }
 
-func (c *CPU) Start(buffer chan descriptor.Descriptor) {
+func (c *CPUTemp) Start(buffer chan descriptor.Descriptor) {
 	c.Enabled.Store(true)
 
 	go func() {
@@ -64,6 +64,6 @@ func (c *CPU) Start(buffer chan descriptor.Descriptor) {
 	}()
 }
 
-func (c *CPU) Stop() {
+func (c *CPUTemp) Stop() {
 	c.Enabled.Store(false)
 }

--- a/pkg/main/main.go
+++ b/pkg/main/main.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/freddiehaddad/swaybar/pkg/cpu"
+	"github.com/freddiehaddad/swaybar/pkg/cpu/temp"
 	"github.com/freddiehaddad/swaybar/pkg/date"
 	"github.com/freddiehaddad/swaybar/pkg/descriptor"
 	"github.com/freddiehaddad/swaybar/pkg/gpu"
@@ -82,15 +82,15 @@ func main() {
 	// create the components
 	for component, settings := range componentConfigs {
 		switch component {
-		case "cpu":
-			log.Println("Creating cpu component")
+		case "cputemp":
+			log.Println("Creating cpu temperature component")
 			interval, err := ParseInterval(settings.Interval)
 			if err != nil {
 				log.Println("Failed to parse interval", interval, err, "using default value of 1s")
 				interval = time.Second
 			}
-			cpu, _ := cpu.New(settings.Sensor, interval)
-			components["cpu"] = cpu
+			cputemp, _ := cputemp.New(settings.Sensor, interval)
+			components["cputemp"] = cputemp
 		case "gpu":
 			log.Println("Creating gpu component")
 			interval, err := ParseInterval(settings.Interval)


### PR DESCRIPTION
In preparation for the cpu utilization component, cpu temperature needs
to be refactored.

The refactoring includes moving the component to:

    pkg/cpu/temp/temp.go

Renaming the component to cputemp is also part of this refactoring.
