### PR TITLE
fix(logging): Update log for CPU and GPU clarity

### DIFF
--- a/pkg/cpu/cpu.go
+++ b/pkg/cpu/cpu.go
@@ -28,7 +28,7 @@ func New(sensor string, interval time.Duration) (*CPU, error) {
 }
 
 func (c *CPU) Update() (descriptor.Descriptor, error) {
-	log.Println("Updating", c.Sensor)
+	log.Println("Updating CPU temperature sensor", c.Sensor)
 	descriptor := descriptor.Descriptor{
 		Component: "cpu",
 		Value:     "",

--- a/pkg/gpu/gpu.go
+++ b/pkg/gpu/gpu.go
@@ -28,7 +28,7 @@ func New(sensor string, interval time.Duration) (*GPU, error) {
 }
 
 func (c *GPU) Update() (descriptor.Descriptor, error) {
-	log.Println("Updating", c.Sensor)
+	log.Println("Updating GPU temperature sensor", c.Sensor)
 	descriptor := descriptor.Descriptor{
 		Component: "gpu",
 		Value:     "",


### PR DESCRIPTION
The update log message for the CPU/GPU components is slightly more
verbose.  This change is mostly for support for additional components in
the same family (i.e. CPU Temperature and CPU Utilization).
