### PR TITLE
feat: Support automatically finding sensor data.

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -56,12 +56,14 @@ cpuutil:
 cputemp:
   # interval: "500ms" # equivalent to 0.5 seconds
   order: 2
-  sensor: "temp1_input"
+  # name: "coretemp"
+  # label: "package"
 
 gpu:
   # interval: "2s" # 2 seconds
   order: 3
-  sensor: "temp1_input"
+  # name: "amdgpu"
+  # label: "edge"
 
 date:
   # interval: "1500000000ns" # equivalent to 1.5 seconds

--- a/pkg/cpu/temp/temp.go
+++ b/pkg/cpu/temp/temp.go
@@ -11,38 +11,68 @@ import (
 	"github.com/freddiehaddad/swaybar/pkg/utils"
 )
 
+const (
+	Name  = "coretemp"
+	Label = "package"
+)
+
 type CPUTemp struct {
-	Sensor   string
-	Interval time.Duration
-	Enabled  atomic.Bool
+	Name       string
+	Label      string
+	SensorPath string
+	Interval   time.Duration
+	Enabled    atomic.Bool
 }
 
-func New(sensor string, interval time.Duration) (*CPUTemp, error) {
+func (c *CPUTemp) init() error {
+	return nil
+}
+
+// Attempt to create a sensor with data coming from the hwmon (name) and
+// sensor (label). If either string is empty, internal default values will
+// be assumed.
+func New(name, label string, interval time.Duration) (*CPUTemp, error) {
 	cpu := &CPUTemp{
-		Sensor:   sensor,
 		Interval: interval,
 	}
 
+	if len(name) == 0 {
+		cpu.Name = Name
+	} else {
+		cpu.Name = name
+	}
+
+	if len(label) == 0 {
+		cpu.Label = Label
+	} else {
+		cpu.Label = label
+	}
+
+	sensorPath, err := utils.FindSensorPath(cpu.Name, cpu.Label)
+	if err != nil {
+		return nil, err
+	}
+
+	cpu.SensorPath = sensorPath
 	cpu.Update()
 	return cpu, nil
 }
 
 func (c *CPUTemp) Update() (descriptor.Descriptor, error) {
-	log.Printf("INFO: Updating CPU temperature sensor=%s", c.Sensor)
+	log.Printf("INFO: Updating CPU temperature sensor=%s", c.Label)
 	descriptor := descriptor.Descriptor{
 		Component: "cputemp",
 		Value:     "",
 	}
 	var sb strings.Builder
 
-	sensor := fmt.Sprintf("/sys/class/hwmon/hwmon3/%s", c.Sensor)
-	sensorValue, err := utils.GetSensorValue(sensor)
+	sensorValue, err := utils.GetSensorValue(c.SensorPath)
 	if err != nil {
-		log.Printf("ERROR: GetSensorValue sensor=%s err=%s", sensor, err)
+		log.Printf("ERROR: GetSensorValue sensor=%s err=%s", c.SensorPath, err)
 		return descriptor, err
 	}
 
-	tempCelcius:= utils.ReadSensorValue(sensorValue)
+	tempCelcius := utils.ReadSensorValue(sensorValue)
 	sb.WriteString(fmt.Sprintf("CPU %5.1f °C", tempCelcius))
 	descriptor.Value = sb.String()
 	return descriptor, nil

--- a/pkg/main/main.go
+++ b/pkg/main/main.go
@@ -24,10 +24,11 @@ func init() {
 
 type Component struct {
 	Interval string `yaml:"interval"`
-	Device   string `yaml:"device"`
-	Sensor   string `yaml:"sensor"`
-	Format   string `yaml:"format"`
 	Order    int    `yaml:"order"`
+	Device   string `yaml:"device"`
+	Name     string `yaml:"name"`
+	Label    string `yaml:"label"`
+	Format   string `yaml:"format"`
 }
 
 func ParseInterval(interval string) (time.Duration, error) {
@@ -90,7 +91,10 @@ func main() {
 				log.Println("Failed to parse interval", interval, err, "using default value of 1s")
 				interval = time.Second
 			}
-			cputemp, _ := cputemp.New(settings.Sensor, interval)
+			cputemp, err := cputemp.New(settings.Name, settings.Label, interval)
+			if err != nil {
+				log.Fatalf("ERROR: Failed to create component=%q err=%q\n", component, err)
+			}
 			components["cputemp"] = cputemp
 		case "cpuutil":
 			log.Println("Creating cpu utilization component")
@@ -108,7 +112,10 @@ func main() {
 				log.Println("Failed to parse interval", interval, err, "using default value of 1s")
 				interval = time.Second
 			}
-			gpu, _ := gpu.New(settings.Sensor, interval)
+			gpu, err := gpu.New(settings.Name, settings.Label, interval)
+			if err != nil {
+				log.Fatalf("ERROR: Failed to create component=%q err=%q\n", component, err)
+			}
 			components["gpu"] = gpu
 		case "network":
 			log.Println("Creating network component")

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,6 +1,9 @@
 package utils
 
-import "testing"
+import (
+	"io/fs"
+	"testing"
+)
 
 func TestGetSensorValue(t *testing.T) {
 	tests := []struct {
@@ -48,6 +51,23 @@ func TestReadSensorValue(t *testing.T) {
 		result := ReadSensorValue(test.input)
 		if result != test.expected {
 			t.Error("Test", index, "failed:", "input", test.input, "expected", test.expected, "got", result)
+		}
+	}
+}
+
+func TestSymbolicLink(t *testing.T) {
+	tests := []struct {
+		input    fs.FileMode
+		expected bool
+	}{
+		{fs.ModeSymlink, true},
+		{0xFFFFFFFF ^ fs.ModeSymlink, false},
+	}
+
+	for index, test := range tests {
+		result := symbolicLink(test.input)
+		if result != test.expected {
+			t.Errorf("Test %d failed result=%v expected=%v\n", index, result, test.expected)
 		}
 	}
 }


### PR DESCRIPTION
The scope of changes include modifications to field values in the
config.yml file.  These changes include the name of the hwmon component
(i.e. coretemp for the cpu, amdgpu for the gpu, etc.) and a label name
for the sensor to read (i.e. package for cpu and edge for gpu).

During the call to New for the CPU and GPU components, an attempt will
be made to find the full system path to the desired sensor data.  If not
found, an error will be returned.
